### PR TITLE
Fix URL encoding in corsAdapter

### DIFF
--- a/src/network/httpClient.ts
+++ b/src/network/httpClient.ts
@@ -34,7 +34,11 @@ const obsidianAdapter: AxiosAdapter = async (config: AxiosRequestConfig): Promis
 };
 
 const corsAdapter: AxiosAdapter = async (config: AxiosRequestConfig): Promise<AxiosResponse<string>> => {
-  const proxied = `https://r.jina.ai/http://${encodeURIComponent(config.url!)}`;
+  let target = config.url ?? "";
+  if (!/^https?:\/\//i.test(target)) {
+    target = `http://${target}`;
+  }
+  const proxied = `https://r.jina.ai/${encodeURIComponent(target)}`;
   const resp = await fetch(proxied, { method: "GET" });
   const text = await resp.text();
   

--- a/tests/httpClient.test.ts
+++ b/tests/httpClient.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createHttpClient } from '../src/network/httpClient';
+
+// Helper response mock
+function mockResponse(body: string) {
+  return {
+    status: 200,
+    statusText: 'OK',
+    text: () => Promise.resolve(body),
+    headers: new Headers(),
+  };
+}
+
+describe('corsAdapter', () => {
+  it('proxies https requests via jina with correct encoding', async () => {
+    const instance = createHttpClient();
+    instance.defaults.adapter = vi.fn().mockRejectedValue({
+      message: 'Network Error',
+      config: { url: 'https://example.com' },
+    });
+
+    const fetchMock = vi.fn().mockResolvedValue(mockResponse('ok'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const resp = await instance.get('https://example.com');
+    expect(resp.data).toBe('ok');
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://r.jina.ai/https%3A%2F%2Fexample.com',
+      { method: 'GET' },
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- ensure corsAdapter properly encodes URLs without duplicating the scheme
- add unit test for https target

## Testing
- `pnpm test` *(fails: `sh: 1: vitest: not found`)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved URL handling for proxied requests to ensure URLs without a scheme are correctly normalized and proxied.

- **Tests**
  - Added tests to verify correct URL transformation and proxying behavior for network requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->