### PR TITLE
Fix __dirname usage in vitest config

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,8 @@
 import { defineConfig } from "vitest/config";
-import { resolve } from "path";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   resolve: {


### PR DESCRIPTION
## Summary
- ensure vitest config works under ESM by deriving `__dirname` from `import.meta.url`

## Testing
- `pnpm install` *(fails: EHOSTUNREACH)*
- `npx tsc --noEmit` *(fails: cannot find modules)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved internal handling of file paths for better compatibility in certain environments. No impact on user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->